### PR TITLE
add range task

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ default_language_version:
   python: python3.10
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v5.0.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer
@@ -12,18 +12,18 @@ repos:
       - id: check-docstring-first
       - id: requirements-txt-fixer
   - repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
+    rev: 7.1.2
     hooks:
     - id: flake8
       args: ["--max-line-length=120","--extend-ignore=E203","--per-file-ignores=.github/scripts/bump_version.py:E402"]
   - repo: https://github.com/ambv/black
-    rev: 23.7.0
+    rev: 25.1.0
     hooks:
     - id: black
       args: [--line-length=130]
       additional_dependencies: ['click==8.0.4']
   - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+    rev: 6.0.1
     hooks:
     - id: isort
       name: isort

--- a/src/configs/tasks-default.yaml
+++ b/src/configs/tasks-default.yaml
@@ -18,14 +18,14 @@
     - n_notes: 15
     - n_notes: 20
 
-- class: RangeMasking
+- class: TimeRangeMasking
   param_range:
     - start_sec: 0
       end_sec: 5
-    - start_sec: 5
-      end_sec: 10
+    - start_sec: 1
+      end_sec: 5
     - start_sec: 0
-      end_sec: 10
+      end_sec: 4
 
 - class: HighNotesMasking
   param_range:

--- a/src/configs/tasks-default.yaml
+++ b/src/configs/tasks-default.yaml
@@ -18,6 +18,15 @@
     - n_notes: 15
     - n_notes: 20
 
+- class: RangeMasking
+  param_range:
+    - start_sec: 0
+      end_sec: 5
+    - start_sec: 5
+      end_sec: 10
+    - start_sec: 0
+      end_sec: 10
+
 - class: HighNotesMasking
   param_range:
     - n_notes: 3

--- a/src/piano_dataset/piano_tasks.py
+++ b/src/piano_dataset/piano_tasks.py
@@ -152,17 +152,15 @@ class TimeRangeMasking(PianoTask):
         prefix_tokens = [
             self.task_token,
             self.task_parameter_token(self.start_sec),
-            self.task_parameter_token(self.end_sec)
+            self.task_parameter_token(self.end_sec),
         ]
         return prefix_tokens
 
     def prompt_target_split(self, notes_df: pd.DataFrame) -> TargetPromptSplit:
         source_df = notes_df.copy()
 
-        # TODO: remove or add to config
-        tolerance = 0.05
         # Find indexes in specified range
-        range_idx = (notes_df["start"] >= self.start_sec - tolerance) & (notes_df["start"] <= self.end_sec + tolerance)
+        range_idx = (notes_df["start"] >= self.start_sec) & (notes_df["start"] <= self.end_sec)
 
         target_df = source_df[range_idx]
         source_df = source_df[~range_idx]

--- a/src/piano_dataset/piano_tasks.py
+++ b/src/piano_dataset/piano_tasks.py
@@ -132,8 +132,8 @@ class BottomLineMasking(PianoTask):
         return target_split
 
 
-class RangeMasking(PianoTask):
-    name = "range_masking"
+class TimeRangeMasking(PianoTask):
+    name = "time_range_masking"
     type = PromptTaskType.COMBINE
     task_token = "<PARAMETRIC_RANGE>"
 
@@ -143,17 +143,9 @@ class RangeMasking(PianoTask):
 
     @property
     def task_name(self) -> str:
-        # *x* reads *times*
+        # x cam be interpreted as (from -- to)
         name = f"{self.name}-x{self.start_sec}-x{self.end_sec}"
         return name
-
-    def _find_idx_in_range(self, notes_df: pd.DataFrame) -> list[int]:
-        # TODO: move to config
-        tolerance = 0.05
-
-        ids = (notes_df["start"] >= self.start_sec - tolerance) & (notes_df["start"] <= self.end_sec + tolerance)
-
-        return ids
 
     @property
     def prefix_tokens(self) -> list[str]:
@@ -167,10 +159,12 @@ class RangeMasking(PianoTask):
     def prompt_target_split(self, notes_df: pd.DataFrame) -> TargetPromptSplit:
         source_df = notes_df.copy()
 
-        range_idx = self._find_idx_in_range(source_df)
+        # TODO: remove or add to config
+        tolerance = 0.05
+        # Find indexes in specified range
+        range_idx = (notes_df["start"] >= self.start_sec - tolerance) & (notes_df["start"] <= self.end_sec + tolerance)
 
         target_df = source_df[range_idx]
-
         source_df = source_df[~range_idx]
 
         target_split = TargetPromptSplit(


### PR DESCRIPTION
## Added a RangeTask.

This task filters `notes_df` that starts between `start_sec` and `end_sec`.

I'm not entirely sure as to the use of two <PARAMETER_x> tokens. I was thinking about some other approaches:
- <PARAMETER_x_y> for range in one token. 
- enclose notes tokens in <RANGE_START> <RANGE_END>. This would be easier to combine with other tasks. to potentially create top_line_in_range task without explicitly defining it.
- <PARAMETER_x> but pre-determine the end after `start + ~5 seconds`. The x would signal the start time.  

## dashboard:

![image](https://github.com/user-attachments/assets/21420eea-6635-4192-aa90-4ec4a83e029d)
